### PR TITLE
fix: perform cleanup only when every KeyPress component was unmounted + use WeakMap

### DIFF
--- a/packages/react-slate/src/components/KeyPress.js
+++ b/packages/react-slate/src/components/KeyPress.js
@@ -26,7 +26,7 @@ const INTERNAL = Symbol('KeyPress_Internal');
 export default class KeyPress extends React.Component<Props> {
   // $FlowFixMe
   static [INTERNAL] = {
-    instanceCount: 0,
+    streams: new WeakMap(),
   };
 
   onKeyPress = (ch: string, key: Key) => {
@@ -41,29 +41,52 @@ export default class KeyPress extends React.Component<Props> {
     if (!disableStreamCleanup) {
       stream.resume();
     }
+
+    // If stream wasn't stored, then the stream was not configured yet.
     // $FlowFixMe
-    if (KeyPress[INTERNAL].instanceCount === 0) {
+    if (!KeyPress[INTERNAL].streams.has(stream)) {
       setRawMode(stream, true);
       readline.emitKeypressEvents(stream);
     }
     stream.addListener('keypress', this.onKeyPress);
+
+    // Store stream and set initial value to 1, so another instance
+    // won't run configuration code again.
     // $FlowFixMe
-    KeyPress[INTERNAL].instanceCount++;
+    if (!KeyPress[INTERNAL].streams.has(stream)) {
+      // $FlowFixMe
+      KeyPress[INTERNAL].streams.set(stream, 1);
+    } else {
+      // $FlowFixMe
+      const count = KeyPress[INTERNAL].streams.get(stream);
+      // $FlowFixMe
+      KeyPress[INTERNAL].streams.set(stream, count + 1);
+    }
   }
 
   componentWillUnmount() {
     const { stream, disableStreamCleanup } = this.props;
     stream.removeListener('keypress', this.onKeyPress);
+
+    // Decrement number of instances of `KeyPress` operating on given stream,
+    // only if the stream was configured and stored.
     // $FlowFixMe
-    KeyPress[INTERNAL].instanceCount--;
-    // $FlowFixMe
-    if (KeyPress[INTERNAL].instanceCount === 0) {
-      setRawMode(stream, false);
-      if (!disableStreamCleanup) {
-        // This needs to be explicitly called, since `readline.emitKeypressEvents`
-        // contains side effects, which prevents node process from exiting.
-        // All code after this line will execute properly.
-        stream.pause();
+    if (KeyPress[INTERNAL].streams.has(stream)) {
+      // $FlowFixMe
+      const count = KeyPress[INTERNAL].streams.get(stream) - 1;
+      // $FlowFixMe
+      KeyPress[INTERNAL].streams.set(stream, count);
+
+      // Cleanup the stream if current instance was the only one left
+      // operating on given stream.
+      if (count === 0) {
+        setRawMode(stream, false);
+        if (!disableStreamCleanup) {
+          // This needs to be explicitly called, since `readline.emitKeypressEvents`
+          // contains side effects, which prevents node process from exiting.
+          // All code after this line will execute properly.
+          stream.pause();
+        }
       }
     }
   }

--- a/packages/react-slate/src/components/KeyPress.js
+++ b/packages/react-slate/src/components/KeyPress.js
@@ -42,18 +42,13 @@ export default class KeyPress extends React.Component<Props> {
       stream.resume();
     }
 
-    // If stream wasn't stored, then the stream was not configured yet.
+    // If stream wasn't stored, then the stream was not configured yet, so
+    // configure it, store and set initial value to 1, so another instance
+    // won't run configuration code again.
     // $FlowFixMe
     if (!KeyPress[INTERNAL].streams.has(stream)) {
       setRawMode(stream, true);
       readline.emitKeypressEvents(stream);
-    }
-    stream.addListener('keypress', this.onKeyPress);
-
-    // Store stream and set initial value to 1, so another instance
-    // won't run configuration code again.
-    // $FlowFixMe
-    if (!KeyPress[INTERNAL].streams.has(stream)) {
       // $FlowFixMe
       KeyPress[INTERNAL].streams.set(stream, 1);
     } else {
@@ -62,6 +57,8 @@ export default class KeyPress extends React.Component<Props> {
       // $FlowFixMe
       KeyPress[INTERNAL].streams.set(stream, count + 1);
     }
+
+    stream.addListener('keypress', this.onKeyPress);
   }
 
   componentWillUnmount() {

--- a/packages/react-slate/src/public/render.js
+++ b/packages/react-slate/src/public/render.js
@@ -8,7 +8,7 @@ import ContainerNode from '../nodes/ContainerNode';
 import hostConfig from '../host/hostConfig';
 import onExit from '../utils/onExit';
 
-const targetMap = new Map();
+const targetMap = new WeakMap();
 
 export default function render(
   element: any,

--- a/packages/react-slate/src/public/renderToTerminal.js
+++ b/packages/react-slate/src/public/renderToTerminal.js
@@ -9,7 +9,7 @@ type Options = {
   height?: number,
 };
 
-const streamMap = new Map();
+const streamMap = new WeakMap();
 
 export function unmountFromTerminal(stream: tty$WriteStream | stream$Writable) {
   if (streamMap.has(stream)) {


### PR DESCRIPTION
## Summary/notes

Perform clean on input stream only after all `KeyPress` components were/are about to be unmounted.

Also, use `WeakMap` in render functions.

## Checklist

* [x] I have added myself to a contributors list.
* [x] I have updated docs (or there's no need to).
