### PR TITLE
fix: handle offscreen elements and prevent crash with negative margins

### DIFF
--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -80,8 +80,8 @@ Supports `positive` and `negative` values including `0`.
 
 ### `left: number`
 
-Specifies the left offset of a [`fixed`](#position-relative-fixed) element from the left edge of the canvas.
+Specifies the left offset of a [`fixed`](#position-relative-fixed) element from the left edge of the canvas. Both positive and negative values (including 0) are supported.
 
 ### `top: number`
 
-Specifies the top offset of a [`fixed`](#position-relative-fixed) element from the top edge of the canvas.
+Specifies the top offset of a [`fixed`](#position-relative-fixed) element from the top edge of the canvas. Both positive and negative values (including 0) are supported.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -52,7 +52,7 @@ Determines whether the content of a [`View`](./view-component.md) or [`Text`](./
 
 ### `margin: string`
 
-Add a margin around the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component.
+Add a margin around the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 **The margin area won't be affected by [`backgroundColor`](#background-color) property.**
 
@@ -65,47 +65,47 @@ Use CSS syntax for applying margin:
 
 ### `marginTop: number`
 
-Adds margin on the top of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component.
+Adds margin on the top of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 **The margin area won't be affected by [`backgroundColor`](#backgroundcolor-string) property.**
 
 ### `marginBottom: number`
 
-Adds margin on the bottom of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component.
+Adds margin on the bottom of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 **The margin area won't be affected by [`backgroundColor`](#backgroundcolor-string) property.**
 
 ### `marginLeft: number`
 
-Adds margin on left side of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component.
+Adds margin on left side of the content of [`View`](./view-component.md) or [`Text`](./text-component.md) component. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 **The margin area won't be affected by [`backgroundColor`](#backgroundcolor-string) property.**
 
 ### `marginRight: number`
 
-Adds margin on the right side of the content of [`View`](./view-component.md) or [`Text`](./text-component.md)component.
+Adds margin on the right side of the content of [`View`](./view-component.md) or [`Text`](./text-component.md)component. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 **The margin area won't be affected by [`backgroundColor`](#backgroundcolor-string) property.**
 
 ### `padding: string`
 
-Same as `margin` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string)property**.
+Same as `margin` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string)property**. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 ### `paddingTop: number`
 
-Same as `marginTop` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**.
+Same as `marginTop` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 ### `paddingBottom: number`
 
-Same as `paddingBottom` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**.
+Same as `paddingBottom` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 ### `paddingLeft: number`
 
-Same as `marginLeft` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**.
+Same as `marginLeft` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 ### `paddingRight: number`
 
-Same as `marginRight` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**.
+Same as `marginRight` but **the padding area will be affected by [`backgroundColor`](#backgroundcolor-string) property**. **Only 0 and positive values are supported**, negative ones are a NOOP.
 
 ### `borderStyle: 'none' | 'solid' | 'double'`
 

--- a/packages/react-slate/src/__tests__/__snapshots__/integration.spec.js.snap
+++ b/packages/react-slate/src/__tests__/__snapshots__/integration.spec.js.snap
@@ -26,3 +26,15 @@ exports[`in integration tests renderToString should apply backgroundColor whole 
                                         
                                         "
 `;
+
+exports[`in integration tests renderToString with fixed positioning should correctly left-trim element with border 1`] = `
+"────┐  
+ello│  
+────┘  "
+`;
+
+exports[`in integration tests renderToString with fixed positioning should correctly left-trim element with border 2`] = `
+"@[31m────┐@[0m  @[0m
+@[39mello@[0m@[39m@[31m│@[0m  @[0m
+@[31m────┘@[0m  @[0m"
+`;

--- a/packages/react-slate/src/__tests__/integration.spec.js
+++ b/packages/react-slate/src/__tests__/integration.spec.js
@@ -41,4 +41,146 @@ describe('in integration tests renderToString', () => {
       )
     ).toMatchSnapshot();
   });
+
+  it('should discard negative margins', () => {
+    expect(
+      renderToString(<View style={{ marginLeft: -2 }}>Hello World</View>, {
+        height: 1,
+      })
+    ).toMatch(/^Hello World/);
+
+    expect(
+      renderToString(<View style={{ marginRight: -2 }}>Hello World</View>, {
+        height: 1,
+      })
+    ).toMatch(/^Hello World/);
+
+    expect(
+      renderToString(
+        <View>
+          <View>Hello</View>
+          <View style={{ marginTop: -1 }}>World</View>
+        </View>,
+        {
+          height: 2,
+          width: 5,
+        }
+      )
+    ).toMatch('Hello\nWorld');
+
+    expect(
+      renderToString(
+        <View>
+          <View style={{ marginBottom: -1 }}>Hello</View>
+          <View>World</View>
+        </View>,
+        {
+          height: 2,
+          width: 5,
+        }
+      )
+    ).toMatch('Hello\nWorld');
+  });
+
+  describe('with fixed positioning', () => {
+    it('should left-trim if left is negative', () => {
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', left: -2 }}>Hello</View>,
+          {
+            height: 1,
+            width: 5,
+          }
+        )
+      ).toMatch(/^llo/);
+    });
+
+    it('should correctly left-trim element with border', () => {
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', left: -2, borderStyle: 'solid' }}>
+            Hello
+          </View>,
+          {
+            height: 3,
+            width: 7,
+          }
+        )
+      ).toMatchSnapshot();
+
+      expect(
+        renderToString(
+          <View
+            style={{ position: 'fixed', left: -2, border: 'solid ansi-red' }}
+          >
+            Hello
+          </View>,
+          {
+            height: 3,
+            width: 7,
+          }
+        )
+      ).toMatchSnapshot();
+    });
+
+    it('should right-trim if left + content width > canvas width', () => {
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', left: 3 }}>Hello</View>,
+          {
+            height: 1,
+            width: 5,
+          }
+        )
+      ).toMatch(/\s{3}He$/);
+    });
+    it('should top-trim if top is negative', () => {
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', top: -1 }}>{'Hello\nWorld'}</View>,
+          {
+            height: 2,
+            width: 5,
+          }
+        )
+      ).toMatch(`World\n${' '.repeat(5)}`);
+
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', top: -1 }}>
+            <View>Hello</View>
+            <View>World</View>
+          </View>,
+          {
+            height: 2,
+            width: 5,
+          }
+        )
+      ).toMatch(`World\n${' '.repeat(5)}`);
+    });
+    it('should top-trim if top + content height > canvas height', () => {
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', top: 1 }}>{'Hello\nWorld'}</View>,
+          {
+            height: 2,
+            width: 5,
+          }
+        )
+      ).toMatch(`${' '.repeat(5)}\nHello`);
+
+      expect(
+        renderToString(
+          <View style={{ position: 'fixed', top: 1 }}>
+            <View>Hello</View>
+            <View>World</View>
+          </View>,
+          {
+            height: 2,
+            width: 5,
+          }
+        )
+      ).toMatch(`${' '.repeat(5)}\nHello`);
+    });
+  });
 });

--- a/packages/react-slate/src/host/AbsoluteCanvas.js
+++ b/packages/react-slate/src/host/AbsoluteCanvas.js
@@ -73,9 +73,17 @@ export default class AbsoluteCanvas {
     { x, y, z }: { x: number, y: number, z: number }
   ) {
     const layer = this.atLayer(z);
-    for (let i = 0; i < nestedTree.length && y + i < layer.length; i++) {
+    for (
+      let i = Math.abs(Math.min(y, 0)); // If y < 0 start from line abs(y), otherwise from 0
+      i < nestedTree.length && y + i < layer.length;
+      i++
+    ) {
+      // Append offsets if x > 0
+      let line = `${'\0'.repeat(Math.max(x, 0))}${nestedTree[i]}`;
+      // Left-trim line if x < 0
+      line = x < 0 ? sliceAnsi(line, Math.abs(x)) : line;
       layer[y + i] = sliceAnsi(
-        mergeAnsiStrings(layer[y + i], `${'\0'.repeat(x)}${nestedTree[i]}`),
+        mergeAnsiStrings(layer[y + i], line),
         0,
         this.size.width
       );

--- a/packages/react-slate/src/host/RelativeCanvas.js
+++ b/packages/react-slate/src/host/RelativeCanvas.js
@@ -12,13 +12,13 @@ function appendOffsets(
   { width, offsetChar }: { width: number, offsetChar: string }
 ) {
   for (let i = 0; i < canvas.length; i++) {
-    canvas[i] = `${offsetChar.repeat(left)}${canvas[i]}${offsetChar.repeat(
-      right
-    )}`;
+    canvas[i] = `${offsetChar.repeat(Math.max(left, 0))}${
+      canvas[i]
+    }${offsetChar.repeat(Math.max(right, 0))}`;
   }
-  for (let i = 0; i < top + bottom; i++) {
+  for (let i = 0; i < Math.max(top, 0) + Math.max(bottom, 0); i++) {
     // $FlowFixMe
-    canvas[i < top ? 'unshift' : 'push'](
+    canvas[i < Math.max(top, 0) ? 'unshift' : 'push'](
       width > 0 ? offsetChar.repeat(width) : ''
     );
   }

--- a/packages/react-slate/src/utils/__tests__/sliceAnsi.spec.js
+++ b/packages/react-slate/src/utils/__tests__/sliceAnsi.spec.js
@@ -1,0 +1,9 @@
+import sliceAnsi from '../sliceAnsi';
+
+test('sliceAnsi', () => {
+  const output = sliceAnsi(
+    '\u001b[38;5;196m│\u001b[39mHello\u001b[38;5;196m│\u001b[39m',
+    2
+  );
+  expect(output).toEqual('\u001b[39mello\u001b[38;5;196m│\u001b[39m');
+});

--- a/packages/react-slate/src/utils/sliceAnsi.js
+++ b/packages/react-slate/src/utils/sliceAnsi.js
@@ -33,7 +33,7 @@ module.exports = (str, begin, end) => {
 
     if (ESCAPES.indexOf(x) !== -1) {
       insideEscape = true;
-      const code = /\d[^m]*/.exec(str.slice(i, str.indexOf('m')));
+      const code = /\d[^m]*/.exec(str.slice(i, str.indexOf('m', i)));
       escapeCode = code === END_CODE ? null : code;
     } else if (insideEscape && x === 'm') {
       insideEscape = false;


### PR DESCRIPTION
<!---
Thank you very much for contributing to the project by making this PR.

Before you submit please make sure to verify all of the points below.
-->

## Summary/notes

Closes #70 
Closes #25 

* properly support negative `left`/`top` and offscreen positioning of `fixed` elements
* prevent crashes, if negative margins or paddings are used (NOOP)

## Checklist

* [x] I have added myself to a contributors list.
* [x] I have updated docs (or there's no need to).
